### PR TITLE
Fixes for markdown and code improvement

### DIFF
--- a/00_merchcat_context.py
+++ b/00_merchcat_context.py
@@ -20,7 +20,7 @@
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC &copy; 2021 Databricks, Inc. All rights reserved. The source in this notebook is provided subject to the Databricks License [https://databricks.com/db-license-source].  All included or referenced third party libraries are subject to the licenses set forth below.
+# MAGIC &copy; 2021 Databricks, Inc. All rights reserved. The source in this notebook is provided subject to the [Databricks License](https://databricks.com/db-license-source).  All included or referenced third party libraries are subject to the licenses set forth below.
 # MAGIC 
 # MAGIC | library                                               | description             | license    | source                                              |
 # MAGIC |-------------------------------------------------------|-------------------------|------------|-----------------------------------------------------|

--- a/01_merchcat_etl.py
+++ b/01_merchcat_etl.py
@@ -236,7 +236,7 @@ display(dbutils.fs.ls(config['model']['train']['hex']))
 
 # COMMAND ----------
 
-input_dir = '{}/final'.format(config['model']['train']['hex'])
+input_dir = f"{config['model']['train']['hex']}/final"
 display(spark.read.format('text').load(input_dir))
 
 # COMMAND ----------

--- a/02_merchcat_ml.py
+++ b/02_merchcat_ml.py
@@ -21,7 +21,7 @@ display(dbutils.fs.ls(config['model']['train']['hex']))
 # distributed storage must be mounted and accessible as a file
 # we ensured files were coalesced into only 1 partition so the whole training set can be read as-is
 import re
-training_file = dbutils.fs.ls('{}/final'.format(config['model']['train']['hex']))[0].path
+training_file = dbutils.fs.ls(f"{config['model']['train']['hex']}/final")[0].path
 training_file = re.sub('dbfs:', '/dbfs', training_file)
 
 # COMMAND ----------
@@ -157,7 +157,7 @@ from utils.merchcat_utils import *
 
 # As fasttext models cannot be automatically pickled by using cloudpickle, we will be storing the model in /dbfs
 # This distributed storage was mounted to disk to be writable from any executor
-fasttext_home = '/dbfs{}'.format(config['model']['path'])
+fasttext_home = f"/dbfs{config['model']['path']}"
 
 # Create model directory if it does not yet exist
 dbutils.fs.mkdirs(config['model']['path'])
@@ -391,7 +391,7 @@ tf = TrainingFile(
 
 file_thresholds = [0.3, 0.25, 0.2, 0.15, 0.10, 0.05]
 training_files = [tf.generate_training_file(sample_rate=t, min_count=50) for t in file_thresholds]
-training_files = ['/dbfs{}'.format(training_file) for training_file in training_files]
+training_files = [f'/dbfs{training_file}' for training_file in training_files]
 
 # COMMAND ----------
 
@@ -464,7 +464,7 @@ display(df[['param', 'value']])
 
 # COMMAND ----------
 
-model_uri = 'runs:/{}/model'.format(best_run_id)
+model_uri = f'runs:/{best_run_id}/model'
 result = mlflow.register_model(model_uri, config['model']['name'])
 version = result.version
 
@@ -479,7 +479,7 @@ client.transition_model_version_stage(
 
 # COMMAND ----------
 
-logged_model = 'models:/{}/production'.format(config['model']['name'])
+logged_model = f"models:/{config['model']['name']}/production"
 loaded_model = mlflow.pyfunc.load_model(logged_model)
 
 # COMMAND ----------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ___
 
 ___
 
-&copy; 2021 Databricks, Inc. All rights reserved. The source in this notebook is provided subject to the Databricks License [https://databricks.com/db-license-source].  All included or referenced third party libraries are subject to the licenses set forth below.
+&copy; 2021 Databricks, Inc. All rights reserved. The source in this notebook is provided subject to the [Databricks License](https://databricks.com/db-license-source).  All included or referenced third party libraries are subject to the licenses set forth below.
 
 | library                                               | description             | license    | source                                              |
 |-------------------------------------------------------|-------------------------|------------|-----------------------------------------------------|

--- a/config/configure_notebook.py
+++ b/config/configure_notebook.py
@@ -16,4 +16,4 @@ with open('config/application.yaml', 'r') as f:
 
 import mlflow
 username = dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()
-mlflow.set_experiment('/Users/{}/{}'.format(username, config['model']['name']))
+mlflow.set_experiment(f"/Users/{username}/{config['model']['name']}"")

--- a/config/configure_notebook.py
+++ b/config/configure_notebook.py
@@ -16,4 +16,4 @@ with open('config/application.yaml', 'r') as f:
 
 import mlflow
 username = dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()
-mlflow.set_experiment(f"/Users/{username}/{config['model']['name']}"")
+mlflow.set_experiment(f"/Users/{username}/{config['model']['name']}")


### PR DESCRIPTION
This includes few fixes:

* Fixed markdown for Databricks License link
* Use f-strings instead of explicit `.format` - it's easier to read code 